### PR TITLE
Fix installation step in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ little computer experience.
 ```
 $ go get -u -v github.com/stayradiated/rango
 $ cd $GOPATH/src/github.com/stayradiated/rango
-$ cd client
+$ cd admin
 $ npm install
 $ gulp
 $ cd ..


### PR DESCRIPTION
Installation instructions say `cd client`, but it's `cd admin`.